### PR TITLE
NITES addition to netpingd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+.python-version

--- a/netpingd
+++ b/netpingd
@@ -22,10 +22,12 @@
 
 """Front end checking pings to evaluate the Warwick one-metre telescope network availability"""
 
+import os
+import re
 import argparse
 import datetime
-import re
 import subprocess
+import platform
 import Pyro4
 
 PYRO_CONFIG = {
@@ -39,14 +41,23 @@ PING_REGEX = r'rtt min/avg/max/mdev = (?P<min>\d+\.\d+)/(?P<avg>\d+\.\d+)/' \
 
 class NetworkPingDaemon:
     """Wraps a ping request to google and ngtshead"""
-    def __init__(self):
+    def __init__(self, instrument):
         self._regex = re.compile(PING_REGEX)
+        self.instrument = instrument
 
     def ping(self, address):
         """Ping an address and return the rtt time in milliseconds"""
-        output = subprocess.check_output(['/usr/bin/ping', '-c1', address], universal_newlines=True,
-                                         timeout=PING_TIMEOUT)
+        ping_str = "-n 1" if  platform.system().lower()=="windows" else "-c 1"
+        output = subprocess.check_output("ping " + ping_str + " " + host)
 
+
+        #if self.instrument == 'onemetre':
+        #    output = subprocess.check_output([PYRO_CONFIG['/usr/bin/ping', '-c1', address],
+        #                                      universal_newlines=True, timeout=PING_TIMEOUT)
+        #else:
+        #output = subprocess.check_output('C:\Windows\system32\ping.exe -n 1 -w {0} {1} '.format(
+        #                                     PING_TIMEOUT*1000,address))
+        
         # The last line of output (ignoring the final newline) contains the ping times
         times = output.split('\n')[-2]
         match = self._regex.match(times)

--- a/netpingd
+++ b/netpingd
@@ -18,17 +18,20 @@
 # pylint: disable=broad-except
 # pylint: disable=too-few-public-methods
 # pylint: disable=no-self-use
+# pylint: disable=invalid-name
 
 """Front end checking pings to evaluate the Warwick one-metre telescope network availability"""
 
+import argparse
 import datetime
 import re
 import subprocess
 import Pyro4
 
-PYRO_HOST = '192.168.0.102'
-PYRO_PORT = 9012
-PYRO_NAME = 'onemetre_netping_daemon'
+PYRO_CONFIG = {
+    'nites'    : ('192.168.0.81', 9012, 'nites_netping_daemon'),
+    'onemetre' : ('192.168.0.102', 9012, 'onemetre_netping_daemon')
+    }
 
 PING_TIMEOUT = 2
 PING_REGEX = r'rtt min/avg/max/mdev = (?P<min>\d+\.\d+)/(?P<avg>\d+\.\d+)/' \
@@ -66,17 +69,23 @@ class NetworkPingDaemon:
                   .format(datetime.datetime.utcnow(), str(exception)))
             return None
 
-def spawn_daemon():
+def spawn_daemon(instrument):
     """Spawns the daemon and registers it with Pyro"""
     Pyro4.config.COMMTIMEOUT = 5
 
-    pyro = Pyro4.Daemon(host=PYRO_HOST, port=PYRO_PORT)
+    pyro = Pyro4.Daemon(host=PYRO_CONFIG[instrument][0],
+                        port=PYRO_CONFIG[instrument][1])
     netping = NetworkPingDaemon()
-    uri = pyro.register(netping, objectId=PYRO_NAME)
+    uri = pyro.register(netping, objectId=PYRO_CONFIG[instrument][2])
 
     print('Starting Network ping daemon with Pyro ID:', uri)
     pyro.requestLoop()
     print('Stopping Network ping daemon with Pyro ID:', uri)
 
 if __name__ == '__main__':
-    spawn_daemon()
+    description = 'Net Pinging Server'
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument('instrument', choices=['onemetre', 'nites'], help='Select an instrument')
+    args = parser.parse_args()
+    spawn_daemon(args.instrument)
+

--- a/netpingd
+++ b/netpingd
@@ -39,8 +39,8 @@ PING_TIMEOUT = 2
 PING_REGEX = {
     'onemetre' : r'rtt min/avg/max/mdev = (?P<min>\d+\.\d+)/(?P<avg>\d+\.\d+)/' \
                  + r'(?P<max>\d+\.\d+)/(?P<mdev>\d+\.\d+) ms',
-    'nites' : r'Minimum = (?P<min>\d+\.\d+)ms, Maximum = (?P<max>\d+\.\d+)ms,' \
-                 + r'Average = (?P<avg>\d+\.\d+)ms' 
+    'nites' : r'    Minimum = (?P<min>\d+)ms, Maximum = (?P<max>\d+)ms, ' \
+                 + r'Average = (?P<avg>\d+)ms' 
     }
 
 class NetworkPingDaemon:

--- a/netpingd
+++ b/netpingd
@@ -52,8 +52,7 @@ class NetworkPingDaemon:
     def ping(self, address):
         """Ping an address and return the rtt time in milliseconds"""
         ping_str = "-n 1" if  platform.system().lower()=="windows" else "-c 1"
-        output = subprocess.check_output("ping " + ping_str + " " + host)
-
+        output = subprocess.check_output("ping " + ping_str + " " + address)
 
         #if self.instrument == 'onemetre':
         #    output = subprocess.check_output([PYRO_CONFIG['/usr/bin/ping', '-c1', address],
@@ -90,7 +89,7 @@ def spawn_daemon(instrument):
 
     pyro = Pyro4.Daemon(host=PYRO_CONFIG[instrument][0],
                         port=PYRO_CONFIG[instrument][1])
-    netping = NetworkPingDaemon()
+    netping = NetworkPingDaemon(instrument)
     uri = pyro.register(netping, objectId=PYRO_CONFIG[instrument][2])
 
     print('Starting Network ping daemon with Pyro ID:', uri)

--- a/netpingd
+++ b/netpingd
@@ -54,13 +54,6 @@ class NetworkPingDaemon:
         pltfrm = platform.system().lower()
         ping_str = "-n 1" if  pltfrm=="windows" else "-c 1"
         output = subprocess.check_output("ping " + ping_str + " " + address)
-
-        #if self.instrument == 'onemetre':
-        #    output = subprocess.check_output([PYRO_CONFIG['/usr/bin/ping', '-c1', address],
-        #                                      universal_newlines=True, timeout=PING_TIMEOUT)
-        #else:
-        #output = subprocess.check_output('C:\Windows\system32\ping.exe -n 1 -w {0} {1} '.format(
-        #                                     PING_TIMEOUT*1000,address))
         
         # The last line of output (ignoring the final newline) contains the ping times
         if pltfrm == 'windows':

--- a/netpingd
+++ b/netpingd
@@ -36,13 +36,17 @@ PYRO_CONFIG = {
     }
 
 PING_TIMEOUT = 2
-PING_REGEX = r'rtt min/avg/max/mdev = (?P<min>\d+\.\d+)/(?P<avg>\d+\.\d+)/' \
-           + r'(?P<max>\d+\.\d+)/(?P<mdev>\d+\.\d+) ms'
+PING_REGEX = {
+    'onemetre' : r'rtt min/avg/max/mdev = (?P<min>\d+\.\d+)/(?P<avg>\d+\.\d+)/' \
+                 + r'(?P<max>\d+\.\d+)/(?P<mdev>\d+\.\d+) ms',
+    'nites' : r'rtt Minimum = (?P<min>\d+\.\d+)ms, Maximum = (?P<max>\d+\.\d+)ms,' \
+                 + r'Average = (?P<avg>\d+\.\d+)ms' 
+    }
 
 class NetworkPingDaemon:
     """Wraps a ping request to google and ngtshead"""
     def __init__(self, instrument):
-        self._regex = re.compile(PING_REGEX)
+        self._regex = re.compile(PING_REGEX[instrument])
         self.instrument = instrument
 
     def ping(self, address):

--- a/netpingd
+++ b/netpingd
@@ -39,7 +39,7 @@ PING_TIMEOUT = 2
 PING_REGEX = {
     'onemetre' : r'rtt min/avg/max/mdev = (?P<min>\d+\.\d+)/(?P<avg>\d+\.\d+)/' \
                  + r'(?P<max>\d+\.\d+)/(?P<mdev>\d+\.\d+) ms',
-    'nites' : r'rtt Minimum = (?P<min>\d+\.\d+)ms, Maximum = (?P<max>\d+\.\d+)ms,' \
+    'nites' : r'Minimum = (?P<min>\d+\.\d+)ms, Maximum = (?P<max>\d+\.\d+)ms,' \
                  + r'Average = (?P<avg>\d+\.\d+)ms' 
     }
 
@@ -51,7 +51,8 @@ class NetworkPingDaemon:
 
     def ping(self, address):
         """Ping an address and return the rtt time in milliseconds"""
-        ping_str = "-n 1" if  platform.system().lower()=="windows" else "-c 1"
+        pltfrm = platform.system().lower()
+        ping_str = "-n 1" if  pltfrm=="windows" else "-c 1"
         output = subprocess.check_output("ping " + ping_str + " " + address)
 
         #if self.instrument == 'onemetre':
@@ -62,7 +63,10 @@ class NetworkPingDaemon:
         #                                     PING_TIMEOUT*1000,address))
         
         # The last line of output (ignoring the final newline) contains the ping times
-        times = output.split('\n')[-2]
+        if pltfrm == 'windows':
+            times = output.split('\r\n')[-2]
+        else:
+            times = output.split('\n')[-2]
         match = self._regex.match(times)
         if match is None:
             raise Exception('Failed to parse ping output: ' + output)

--- a/netpingd.service
+++ b/netpingd.service
@@ -7,7 +7,7 @@ After=network-online.target
 [Service]
 Restart=on-failure
 Type=simple
-ExecStart=/usr/bin/env python3 -u /usr/bin/netpingd
+ExecStart=/usr/bin/env python3 -u /usr/bin/netpingd onemetre
 StandardOutput=syslog
 StandardError=syslog
 


### PR DESCRIPTION
To use netpingd on windows for NITES requires adding an instrument command line argument for netpingd and updated regex and pyro settings. I've tested this on windows and it seems to work fine. 
